### PR TITLE
Update conversion-pipeline.ts for @opennextjs/cloudflare@0.6.0 compat

### DIFF
--- a/app/lib/conversion-pipeline.ts
+++ b/app/lib/conversion-pipeline.ts
@@ -129,7 +129,7 @@ export class ConversionPipeline {
     
     const configPath = path.join(this.options.projectPath, 'open-next.config.ts');
     const config = `import { defineCloudflareConfig } from "@opennextjs/cloudflare";
-${this.options.enableKVCache ? 'import kvIncrementalCache from "@opennextjs/cloudflare/kv-cache";' : ''}
+${this.options.enableKVCache ? 'import kvIncrementalCache from "@opennextjs/cloudflare/overrides/incremental-cache/kv-incremental-cache";' : ''}
 
 export default defineCloudflareConfig({
 ${this.options.enableKVCache ? '  incrementalCache: kvIncrementalCache,' : ''}


### PR DESCRIPTION
There is a breaking change from @opennextjs/cloudflare 
https://github.com/opennextjs/opennextjs-cloudflare/releases/tag/%40opennextjs%2Fcloudflare%400.6.0
P.S. I also needed to add `--force` to `npm install` commands for dependency conflict.